### PR TITLE
Simplify get_tracker! to follow let-it-crash pattern

### DIFF
--- a/test/ecto_litefs_test.exs
+++ b/test/ecto_litefs_test.exs
@@ -39,8 +39,8 @@ defmodule EctoLiteFSTest do
       Supervisor.stop(sup)
     end
 
-    test "raises with helpful message when instance not running" do
-      assert_raise ArgumentError, ~r/EctoLiteFS instance :unknown_instance is not running/, fn ->
+    test "raises when instance not running" do
+      assert_raise ArgumentError, ~r/unknown registry/, fn ->
         EctoLiteFS.get_tracker!(:unknown_instance, SomeRepo)
       end
     end


### PR DESCRIPTION
Eliminates TOCTOU race condition in get_tracker!/2 and let it crash!