### PR TITLE
Simplify API by using repo module as unique identifier

### DIFF
--- a/test/ecto_litefs/config_test.exs
+++ b/test/ecto_litefs/config_test.exs
@@ -5,11 +5,10 @@ defmodule EctoLiteFS.ConfigTest do
 
   describe "new!/1" do
     test "returns config struct with valid options" do
-      config = Config.new!(repo: MyApp.Repo, name: :my_litefs)
+      config = Config.new!(repo: MyApp.Repo)
 
       assert %Config{} = config
       assert config.repo == MyApp.Repo
-      assert config.name == :my_litefs
       assert config.primary_file == "/litefs/.primary"
       assert config.poll_interval == 30_000
       assert config.event_stream_url == "http://localhost:20202/events"
@@ -22,7 +21,6 @@ defmodule EctoLiteFS.ConfigTest do
       config =
         Config.new!(
           repo: MyApp.Repo,
-          name: :my_litefs,
           primary_file: "/custom/.primary",
           poll_interval: 10_000,
           event_stream_url: "http://custom:8080/events",
@@ -41,59 +39,47 @@ defmodule EctoLiteFS.ConfigTest do
 
     test "raises when :repo is missing" do
       assert_raise ArgumentError, "EctoLiteFS.Config requires :repo option", fn ->
-        Config.new!(name: :my_litefs)
-      end
-    end
-
-    test "raises when :name is missing" do
-      assert_raise ArgumentError, "EctoLiteFS.Config requires :name option", fn ->
-        Config.new!(repo: MyApp.Repo)
+        Config.new!([])
       end
     end
 
     test "raises when :repo is not an atom" do
       assert_raise ArgumentError, "EctoLiteFS.Config :repo must be an atom", fn ->
-        Config.new!(repo: "MyApp.Repo", name: :my_litefs)
-      end
-    end
-
-    test "raises when :name is not an atom" do
-      assert_raise ArgumentError, "EctoLiteFS.Config :name must be an atom", fn ->
-        Config.new!(repo: MyApp.Repo, name: "not_an_atom")
+        Config.new!(repo: "MyApp.Repo")
       end
     end
 
     test "raises when :poll_interval is not a positive integer" do
       assert_raise ArgumentError, ~r/:poll_interval must be a positive integer/, fn ->
-        Config.new!(repo: MyApp.Repo, name: :my_litefs, poll_interval: -1)
+        Config.new!(repo: MyApp.Repo, poll_interval: -1)
       end
 
       assert_raise ArgumentError, ~r/:poll_interval must be a positive integer/, fn ->
-        Config.new!(repo: MyApp.Repo, name: :my_litefs, poll_interval: 0)
+        Config.new!(repo: MyApp.Repo, poll_interval: 0)
       end
 
       assert_raise ArgumentError, ~r/:poll_interval must be a positive integer/, fn ->
-        Config.new!(repo: MyApp.Repo, name: :my_litefs, poll_interval: "1000")
+        Config.new!(repo: MyApp.Repo, poll_interval: "1000")
       end
     end
 
     test "raises when :cache_ttl is not a positive integer" do
       assert_raise ArgumentError, ~r/:cache_ttl must be a positive integer/, fn ->
-        Config.new!(repo: MyApp.Repo, name: :my_litefs, cache_ttl: -1)
+        Config.new!(repo: MyApp.Repo, cache_ttl: -1)
       end
     end
 
     test "raises when :refresh_grace_period is not a positive integer" do
       assert_raise ArgumentError, ~r/:refresh_grace_period must be a positive integer/, fn ->
-        Config.new!(repo: MyApp.Repo, name: :my_litefs, refresh_grace_period: 0)
+        Config.new!(repo: MyApp.Repo, refresh_grace_period: 0)
       end
 
       assert_raise ArgumentError, ~r/:refresh_grace_period must be a positive integer/, fn ->
-        Config.new!(repo: MyApp.Repo, name: :my_litefs, refresh_grace_period: -1)
+        Config.new!(repo: MyApp.Repo, refresh_grace_period: -1)
       end
 
       assert_raise ArgumentError, ~r/:refresh_grace_period must be a positive integer/, fn ->
-        Config.new!(repo: MyApp.Repo, name: :my_litefs, refresh_grace_period: "500")
+        Config.new!(repo: MyApp.Repo, refresh_grace_period: "500")
       end
     end
   end

--- a/test/ecto_litefs/poller_test.exs
+++ b/test/ecto_litefs/poller_test.exs
@@ -6,6 +6,12 @@ defmodule EctoLiteFS.PollerTest do
   alias EctoLiteFS.Config
   alias EctoLiteFS.Poller
 
+  defmodule TestRepo do
+    use Ecto.Repo,
+      otp_app: :ecto_litefs,
+      adapter: Ecto.Adapters.SQLite3
+  end
+
   describe "start_link/1" do
     test "starts the poller with the correct name" do
       {:ok, temp_dir} = Briefly.create(type: :directory)
@@ -14,23 +20,22 @@ defmodule EctoLiteFS.PollerTest do
       config =
         Config.new!(
           repo: TestRepo,
-          name: :poller_test_1,
           primary_file: primary_file,
           poll_interval: 60_000
         )
 
       {:ok, pid} = Poller.start_link(config)
       assert Process.alive?(pid)
-      assert Process.whereis(Poller.process_name(:poller_test_1)) == pid
+      assert Process.whereis(Poller.process_name(TestRepo)) == pid
 
       GenServer.stop(pid)
     end
   end
 
   describe "process_name/1" do
-    test "returns module-based name for instance" do
-      assert Poller.process_name(:my_litefs) == :"Elixir.EctoLiteFS.Poller.my_litefs"
-      assert Poller.process_name(:other) == :"Elixir.EctoLiteFS.Poller.other"
+    test "returns module-based name for repo" do
+      assert Poller.process_name(MyApp.Repo) == :"Elixir.EctoLiteFS.Poller.MyApp.Repo"
+      assert Poller.process_name(OtherRepo) == :"Elixir.EctoLiteFS.Poller.OtherRepo"
     end
   end
 
@@ -42,7 +47,6 @@ defmodule EctoLiteFS.PollerTest do
       config =
         Config.new!(
           repo: TestRepo,
-          name: :poller_test_primary,
           primary_file: primary_file,
           poll_interval: 50
         )
@@ -66,7 +70,6 @@ defmodule EctoLiteFS.PollerTest do
       config =
         Config.new!(
           repo: TestRepo,
-          name: :poller_test_replica,
           primary_file: primary_file,
           poll_interval: 50
         )
@@ -88,7 +91,6 @@ defmodule EctoLiteFS.PollerTest do
       config =
         Config.new!(
           repo: TestRepo,
-          name: :poller_test_interval,
           primary_file: primary_file,
           poll_interval: 100
         )
@@ -114,7 +116,6 @@ defmodule EctoLiteFS.PollerTest do
       config =
         Config.new!(
           repo: TestRepo,
-          name: :poller_test_nonexistent,
           primary_file: "/nonexistent/deeply/nested/path/.primary",
           poll_interval: 50
         )


### PR DESCRIPTION
Removes the `:name` option, will use the repo module itself as the unique identifier.